### PR TITLE
Allowing for null to be used for string arguments.

### DIFF
--- a/src/Common/Api/Parameter.php
+++ b/src/Common/Api/Parameter.php
@@ -285,6 +285,11 @@ class Parameter
             return true;
         }
 
+        // allow string nulls
+        if ($this->type == 'string' && $userValue === null) {
+          return true;
+        }
+
         return gettype($userValue) == $this->type;
     }
 

--- a/src/Networking/v2/Models/Subnet.php
+++ b/src/Networking/v2/Models/Subnet.php
@@ -5,6 +5,7 @@ namespace OpenStack\Networking\v2\Models;
 use OpenStack\Common\Resource\OperatorResource;
 use OpenStack\Common\Resource\Listable;
 use OpenStack\Common\Resource\Creatable;
+use OpenStack\Common\Resource\Updateable;
 use OpenStack\Common\Resource\Deletable;
 use OpenStack\Common\Resource\Retrievable;
 
@@ -13,7 +14,7 @@ use OpenStack\Common\Resource\Retrievable;
  *
  * @property \OpenStack\Networking\v2\Api $api
  */
-class Subnet extends OperatorResource implements Listable, Retrievable, Creatable, Deletable
+class Subnet extends OperatorResource implements Listable, Retrievable, Creatable, Deletable, Updateable
 {
     /** @var string */
     public $id;
@@ -113,5 +114,19 @@ class Subnet extends OperatorResource implements Listable, Retrievable, Creatabl
     public function delete()
     {
         $this->executeWithState($this->api->deleteSubnet());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getAttrs(array $keys)
+    {
+      $output = parent::getAttrs($keys);
+
+      if ($this->gatewayIp === '') {
+        $output['gatewayIp'] = null;
+      }
+
+      return $output;
     }
 }


### PR DESCRIPTION
This is needed because for the subnet::update() call gatewayIp can be 'null' even though it's a string type.  Null in this case means "remove the gatewayIp".